### PR TITLE
Add vulnerability reference to README.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -49,6 +49,10 @@ Full clean and build of all modules
 ## Usage example
 https://kb.timebase.info/libs.html
 
+## Releases
+The following file lists known Timebase CE vulnerabilities:
+
+https://github.com/finos/TimeBase-CE/blob/main/CVE.md
 
 ## Contributing
 


### PR DESCRIPTION
## Description
This PR adds `https://github.com/finos/TimeBase-CE/blob/main/CVE.md` to `README.md` to disclose known Timebase CE vulnerabilities.

### Change
```
## Releases
The following file lists known Timebase CE vulnerabilities:

https://github.com/finos/TimeBase-CE/blob/main/CVE.md
```