### PR TITLE
Bugifx: fix potential XXE vulnerabilty

### DIFF
--- a/java/timebase/server/src/main/java/com/epam/deltix/qsrv/hf/tickdb/http/TimebaseServlet.java
+++ b/java/timebase/server/src/main/java/com/epam/deltix/qsrv/hf/tickdb/http/TimebaseServlet.java
@@ -49,6 +49,9 @@ import static com.epam.deltix.qsrv.hf.tickdb.http.AbstractHandler.*;
 import static com.epam.deltix.qsrv.hf.tickdb.http.HTTPProtocol.marshall;
 import static com.epam.deltix.qsrv.hf.tickdb.http.HTTPProtocol.LOGGER;
 
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
 /**
  *
  */
@@ -99,7 +102,16 @@ public class TimebaseServlet extends HttpServlet {
                             LOGGER.fine("request: " + xml);
                         }
 
-                        body = um.unmarshal(new StringReader(xml));
+                        XMLInputFactory xif = XMLInputFactory.newFactory();
+                        xif.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+                        xif.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+                        XMLStreamReader xsr = null;
+                        try {
+                            xsr = xif.createXMLStreamReader(new StringReader(xml));
+                        } catch(XMLStreamException e) {
+                            throw new RuntimeException(e);
+                        }
+                        body = um.unmarshal(xsr);
                     } catch (InterruptedException e) {
                         throw new RuntimeException(e);
                     }


### PR DESCRIPTION
Disable resolution of XML external entities in document-type-definition (DTD)

https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#jaxb-unmarshaller